### PR TITLE
Add support for a horizontal thirds split mode

### DIFF
--- a/src/menu_selection.ts
+++ b/src/menu_selection.ts
@@ -1,7 +1,4 @@
-const enum InnerSelection {
-	MAXIMIZE = 0,
-	MINIMIZE
-}
+/// <reference path="menu.ts" />
 
 const enum Ring {
 	NONE = 0,
@@ -12,22 +9,23 @@ const enum Ring {
 interface MenuSelection {
 	ring: Ring
 	index: number
+	mode: Menu.SplitMode
 }
 
 module MenuSelection {
-	export const None: MenuSelection = { ring: Ring.NONE, index: 0 }
+	export const None: MenuSelection = { ring: Ring.NONE, index: 0, mode: Menu.SplitMode.FOUR }
 
 	export function eq(a: MenuSelection, b: MenuSelection) {
-		return a.ring == b.ring && a.index == b.index;
+		return a.ring == b.ring && a.index == b.index && a.mode == b.mode;
 	}
-	export function eqTo(a: MenuSelection, ring: Ring, location: number) {
-		return a.ring == ring && a.index == location;
+	export function eqTo(a: MenuSelection, ring: Ring, location: number, mode: Menu.SplitMode) {
+		return a.ring == ring && a.index == location && a.mode == mode;
 	}
 
-	export function Inner(sel: InnerSelection): MenuSelection {
-		return { ring: Ring.INNER, index: sel };
+	export function Inner(sel: Anchor, mode: Menu.SplitMode): MenuSelection {
+		return { ring: Ring.INNER, index: sel, mode: mode };
 	}
-	export function Outer(sel: Anchor): MenuSelection {
-		return { ring: Ring.OUTER, index: sel };
+	export function Outer(sel: Anchor, mode: Menu.SplitMode): MenuSelection {
+		return { ring: Ring.OUTER, index: sel, mode: mode };
 	}
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -8,6 +8,9 @@ module Preview {
 	const MANIPULATION_SCALE = 2.2;
 	const MINIMUM_SIZE = 20;
 
+    const ONE_THIRD = 1.0 / 3.0;
+    const TWO_THIRD = 2.0 / 3.0;
+
 	export function oppose(loc: Anchor): Anchor {
 		return (loc + 4) % 8; // Magic!
 	}
@@ -21,14 +24,17 @@ module Preview {
 		private windowRect: Rect;
 		private win: WindowType;
 		private windowHidden: boolean;
+		private menu: Menu.Menu<any>;
 		ui: Actor
 		resizeCorner: Anchor;
 		trackingOrigin: Point;
 
-		constructor(Sys: System<WindowType>,
+		constructor(menu: Menu.Menu<any>,
+				Sys: System<WindowType>,
 				size: Point, windowRect: Rect,
 				win: WindowType)
 		{
+			this.menu = menu;
 			this.Sys = Sys;
 			this.size = size;
 			this.ui = Sys.newClutterActor();
@@ -48,62 +54,130 @@ module Preview {
 
 		private selectOuter(loc: Anchor): Rect {
 			const size = this.size;
-			switch (loc) {
-				case Anchor.LEFT:
-					return {
-						pos: Point.ZERO,
-						size: Point.scale({ x: 0.5, y: 1 }, size),
-					}
-				case Anchor.TOPLEFT:
-					return {
-						pos: Point.ZERO,
-						size: Point.scaleConstant(0.5, size),
-					}
-				case Anchor.TOP:
-					return {
-						pos: Point.ZERO,
-						size: Point.scale({ x: 1, y: 0.5 }, size),
-					}
-				case Anchor.TOPRIGHT:
-					return {
-						pos: Point.scale({ x: 0.5, y: 0 }, size),
-						size: Point.scaleConstant(0.5, size),
-					}
-				case Anchor.RIGHT:
-					return {
-						pos: Point.scale({ x: 0.5, y: 0 }, size),
-						size: Point.scale({ x: 0.5, y: 1 }, size),
-					}
-				case Anchor.BOTTOMRIGHT:
-					return {
-						pos: Point.scaleConstant(0.5, size),
-						size: Point.scaleConstant(0.5, size),
-					}
-				case Anchor.BOTTOM:
-					return {
-						pos: Point.scale({ x: 0, y: 0.5 }, size),
-						size: Point.scale({ x: 1, y: 0.5 }, size),
-					}
-				case Anchor.BOTTOMLEFT:
-					return {
-						pos: Point.scale({ x: 0, y: 0.5}, size),
-						size: Point.scaleConstant(0.5, size),
-					}
+			switch (this.menu.getSplitState()) {
+				case Menu.SplitMode.FOUR:
+					switch (loc) {
+					case Anchor.LEFT:
+						return {
+							pos: Point.ZERO,
+							size: Point.scale({ x: 0.5, y: 1 }, size),
+						}
+					case Anchor.TOPLEFT:
+						return {
+							pos: Point.ZERO,
+							size: Point.scaleConstant(0.5, size),
+						}
+					case Anchor.TOP:
+						return {
+							pos: Point.ZERO,
+							size: Point.scale({ x: 1, y: 0.5 }, size),
+						}
+					case Anchor.TOPRIGHT:
+						return {
+							pos: Point.scale({ x: 0.5, y: 0 }, size),
+							size: Point.scaleConstant(0.5, size),
+						}
+					case Anchor.RIGHT:
+						return {
+							pos: Point.scale({ x: 0.5, y: 0 }, size),
+							size: Point.scale({ x: 0.5, y: 1 }, size),
+						}
+					case Anchor.BOTTOMRIGHT:
+						return {
+							pos: Point.scaleConstant(0.5, size),
+							size: Point.scaleConstant(0.5, size),
+						}
+					case Anchor.BOTTOM:
+						return {
+							pos: Point.scale({ x: 0, y: 0.5 }, size),
+							size: Point.scale({ x: 1, y: 0.5 }, size),
+						}
+					case Anchor.BOTTOMLEFT:
+						return {
+							pos: Point.scale({ x: 0, y: 0.5}, size),
+							size: Point.scaleConstant(0.5, size),
+						}
+				}
+			case Menu.SplitMode.SIX:
+				switch (loc) {
+					case Anchor.LEFT:
+						return {
+							pos: Point.ZERO,
+							size: Point.scale({ x: ONE_THIRD, y: 1 }, size),
+						}
+					case Anchor.TOPLEFT:
+						return {
+							pos: Point.ZERO,
+							size: Point.scale({ x: ONE_THIRD, y: 0.5 }, size),
+						}
+					case Anchor.TOP:
+						return {
+							pos: Point.scale({ x: ONE_THIRD, y: 0 }, size),
+							size: Point.scale({ x: ONE_THIRD, y: 0.5 }, size),
+						}
+					case Anchor.TOPRIGHT:
+						return {
+							pos: Point.scale({ x: TWO_THIRD, y: 0 }, size),
+							size: Point.scale({ x: ONE_THIRD, y: 0.5 }, size),
+						}
+					case Anchor.RIGHT:
+						return {
+							pos: Point.scale({ x: TWO_THIRD, y: 0 }, size),
+							size: Point.scale({ x: ONE_THIRD, y: 1 }, size),
+						}
+					case Anchor.BOTTOMRIGHT:
+						return {
+							pos: Point.scale({ x: TWO_THIRD, y: 0.5 }, size),
+							size: Point.scale({ x: ONE_THIRD, y: 0.5 }, size),
+						}
+					case Anchor.BOTTOM:
+						return {
+							pos: Point.scale({ x: ONE_THIRD, y: 0.5 }, size),
+							size: Point.scale({ x: ONE_THIRD, y: 0.5 }, size),
+						}
+					case Anchor.BOTTOMLEFT:
+						return {
+							pos: Point.scale({ x: 0, y: 0.5 }, size),
+							size: Point.scale({ x: ONE_THIRD, y: 0.5 }, size),
+						}
+				}
 			}
 			return null;
 		}
 
-		private selectInner(sel: InnerSelection): Rect {
-			switch (sel) {
-				case InnerSelection.MAXIMIZE:
-					return {
-						pos: Point.ZERO,
-						size: this.size,
+		private selectInner(sel: Anchor): Rect {
+			switch (this.menu.getSplitState()) {
+				case Menu.SplitMode.FOUR:
+					switch (sel) {
+						case Anchor.TOP:
+							return {
+								pos: Point.ZERO,
+								size: this.size,
+							}
+						case Anchor.BOTTOM:
+						default:
+							return null;
 					}
-
-				case InnerSelection.MINIMIZE:
-				default:
-					return null;
+				case Menu.SplitMode.SIX:
+					switch (sel) {
+						case Anchor.LEFT:
+							return {
+								pos: Point.ZERO,
+								size: Point.scale({ x: TWO_THIRD, y: 1 }, this.size),
+							}
+						case Anchor.RIGHT:
+							return {
+								pos: Point.scale({ x: ONE_THIRD, y: 0 }, this.size),
+								size: Point.scale({ x: TWO_THIRD, y: 1 }, this.size),
+							}
+						case Anchor.BOTTOM:
+							return {
+								pos: Point.scale({ x: ONE_THIRD, y: 0 }, this.size),
+								size: Point.scale({ x: ONE_THIRD, y: 1 }, this.size),
+							}
+						default:
+							return null;
+					}
 			}
 		}
 


### PR DESCRIPTION
I have really enjoyed this extension over the last few years, but I'm usually using a 4K monitor. While splitting the screen horizontally into two is quite convenient, it is not a very good use of screen real estate, as it can easily fit three windows side-by-side. 
This PR shows a proof-of-concept of exactly that, making it easier to organise windows when you really need every inch of space.

Imagine the screen as:
```
+-+-+-+
|1|2|3|
+-+-+-+
|4|5|6|
+-+-+-+
```

By pressing `a` (or `Win-a`) from the classical mode, the following tiling
options become available:
- Align as sixth: window fills one of 1-6.
  Available via the top- and bottom-{left, center, right} outer slices.
- Align as thirds: window fills either 1+4, 2+5, or 3+6.
  Available via the outer left/right slices, and the inner bottom.
- Align as two-thirds: window fills either 1+4+2+5 or 2+5+3+6.
  Available via the inner left/right slices.

Arrow keys transition gracefully between those options as expected.