### PR TITLE
fix multi-monitor bugs on using distribute/fill-space/swap

### DIFF
--- a/src/gnome_shell.ts
+++ b/src/gnome_shell.ts
@@ -183,12 +183,12 @@ module GnomeSystem {
 	];
 
 	function listWindows(win?: MetaWindow): Array<MetaWindow> {
-		// XXX is this multi-monitor compatible?
 		const display = (win == null) ? global.display : win.get_display();
-		const screenNo = display.get_current_monitor();
-		return display.get_workspace_manager().get_active_workspace().list_windows().filter(function(w: MetaWindow) {
+		const screenNo = (win == null) ? display.get_current_monitor() : win.get_monitor();
+		let windows = display.get_workspace_manager().get_active_workspace().list_windows();
+		return windows.filter(function(w: MetaWindow) {
 			return (
-				w.get_display().get_current_monitor() == screenNo
+				w.get_monitor() == screenNo
 				&& VISIBLE_WINDOW_TYPES.indexOf(w.get_window_type()) !== -1
 			);
 		});


### PR DESCRIPTION
Previously considered windows from the current workspace.
So when there was 2 windows at monitor1 and 4 windows at monitor2, it arranged a 6 places grid for the monitor1. When a distribute command was used it arranged following this grid but the windows remained in respective monitor, 2 @1 and 4 @2.

Now consider windows from the monitor of the current window only.
So the windows from the other monitor in the current workspace are not affected and the grid are calculated correctly.
In the example given, it will calculated a 2 places grid for the monitor1.
Tested with two 1920x1280 monitors using ubuntu disco.