### PR TITLE
fix many hotkey conflicts and inconscistencies with a new schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,98 @@
-<img src="http://gfxmonk.net/dist/status/project/slinger.png">
 
+# Slinger
 
-<img src="https://github.com/timbertson/slinger/raw/master/img/icon.png" width="128" height="128" align="left">
+![Slinger Extension](http://gfxmonk.net/dist/status/project/slinger.png)
 
-# Slinger:
+![Slinger Icon](img/icon.png){:height="128px" width="128px"}
 
-Slinger is a simple app for window manipulation. It provides multiple methods (via both mouse and keyboard) for moving and sizing windows quickly. [**Here's a quick screencast**](https://www.youtube.com/watch?v=JnZDxHSlQKM). The main interface is a circular popup menu which allows quick selection of various presets (half screen + quarter screen), plus plenty of mouse + keyboard shortcuts for moving & resizing.
+### Overview
+
+Slinger is a simple app for window manipulation. It provides multiple methods (via both mouse and keyboard) for moving and sizing windows quickly. 
+The main interface is a circular popup menu which allows quick selection of various presets (half screen + quarter screen), plus plenty of mouse + keyboard shortcuts for moving & resizing.
+[**Here's a quick screencast**](https://www.youtube.com/watch?v=JnZDxHSlQKM).
 
 ---
 
 ### Global hotkeys
 
- - win+a: show slinger
- - win+shift+8 (asterisk): splat windows - applies a basic tiling layout so you can see all windows
- - win+z: toggle maximize
- - win+j: next window
- - win+k: previous window
- - win+shift+j: swap with next
- - win+shift+k: swap with previous
- - win+alt+j: next workspace
- - win+alt+k: previous workspace
- - win+alt+shift+j: bring window to next workspace
- - win+alt+shift+k: bring window to previous workspace
+| Category | Slinger Shotcut                                               | Action                              |
+|----------|:-------------------------------------------------------------:|-------------------------------------|
+| Arrange  | <kbd>Win</kbd>+<kbd>W</kbd>                                   | Show arrange window menu            |
+|          | <kbd>Win</kbd>+<kbd>G</kbd>                                   | Distribute/tile/splat windows       |
+|          | <kbd>Win</kbd>+<kbd>F</kbd>                                   | Fill available space with window    |
+| Move     | <kbd>Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Right</kbd>               | Move window right                   |
+|          | <kbd>Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Left</kbd>                | Move window left                    |
+|          | <kbd>Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Up</kbd>                  | Move window up                      |
+|          | <kbd>Win</kbd>+<kbd>Ctrl</kbd>+<kbd>Down</kbd>                | Move window down                    |
+| Swap     | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Right</kbd>                | Swap with next window               |
+|          | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Left</kbd>                 | Swap with previous window           |
+|          | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Up</kbd>                   | Swap with largest window            |
+| Resize   | <kbd>Win</kbd>+<kbd>Plus</kbd>                                | Increase window's size              |
+|          | <kbd>Win</kbd>+<kbd>Minus</kbd>                               | Decrease window's size              |
+|          | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Plus</kbd>                 | Increase window's width             |
+|          | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Minus</kbd>                | Decrease window's width             |
+|          | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Multiply</kbd>             | Increase window's height            |
+|          | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Divide</kbd>               | Decrease window's height            |
+| State    | <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>H</kbd>                  | Un-minimize last window             |
+|          | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd>                    | Toggle windows maximized            |
+| Focus    | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Tab</kbd>                  | Change focus to the next window     |
+|          | <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd> | Change focus to the previous window |
 
-### Slinger menu:
+### Slinger menu
 
- - inner ring: maximize / minimize
- - sides: half screen (top/bottom/left/right)
- - diagonals: quarter screen
+| Menu Control                            | Action                              |
+|-----------------------------------------|-------------------------------------|
+| Inner ring                              | Maximize / minimize                 |
+| Sides                                   | Half screen (top/bottom/left/right) |
+| Diagonals                               | Quarter screen                      |
+| <kbd>Arrows</kbd> / <kbd>H/J/K/L</kbd>  | Select a preset                     |
+| <kbd>Space</kbd> / <kbd>Tab</kbd>       | Enter modify mode                   |
 
- - arrows / hjkl: select a preset
- - space/tab: enter modify mode
+### Modify mode
 
-### Modify mode:
+|             Keyboard            |         Action        |
+|:-------------------------------:|:---------------------:|
+| <kbd>Ctrl</kbd>+<kbd>Move</kbd> |      Move window      |
+|  <kbd>Alt</kbd>+<kbd>Move</kbd> | Resize closest corner |
 
- - ctrl+move: move window
- - alt+move: resize closest corner
+### Modifiers
 
-### Modifiers:
+These can be uses as-is in "modify mode":
 
-These can be uses as-is in "modify mode", or used globally (without showing slinger) by also holding down win (super)
+|            Keyboard           |       Action      |
+|:-----------------------------:|:-----------------:|
+|        <kbd>Plus</kbd>        |       Shrink      |
+|        <kbd>Minus</kbd>       |        Grow       |
+|          <kbd>H</kbd>         |     Move left     |
+|          <kbd>L</kbd>         |     Move right    |
+|          <kbd>U</kbd>         |     Move down     |
+|          <kbd>I</kbd>         |      Move up      |
+| <kbd>Shift</kbd>+<kbd>H</kbd> | Shrink horizontal |
+| <kbd>Shift</kbd>+<kbd>L</kbd> |  Grow horizontal  |
+| <kbd>Shift</kbd>+<kbd>I</kbd> |  Shrink vertical  |
+| <kbd>Shift</kbd>+<kbd>u</kbd> |   Grow vertical   |
 
- - equals: shrink
- - minus: grow
- - h: move left
- - l: move right
- - u: move down
- - i: move up
- - shift+h: shrink horizontal
- - shift+l: grow horizontal
- - shift+i: shrink vertical
- - shift+u: grow vertical
+### Related gnome hotkeys
+
+| Slinger Actions |         Key Combination        |              Hotkeys             | Gnome Related     |         Key Combination         |                             Hotkeys                            |
+|-----------------|:------------------------------:|:--------------------------------:|-------------------|:-------------------------------:|:--------------------------------------------------------------:|
+| Move Window     | <kbd>Win</kbd>+<kbd>Ctrl</kbd> | <kbd>Left</kbd> <kbd>Right</kbd> | Tile/Split Window |          <kbd>Win</kbd>         |                <kbd>Left</kbd> <kbd>Right</kbd>                |
+| Swap Window     |  <kbd>Win</kbd>+<kbd>Alt</kbd> | <kbd>Left</kbd> <kbd>Right</kbd> | Move to Screen    |          <kbd>Win</kbd>         | <kbd>Left</kbd> <kbd>Right</kbd> <kbd>Up</kbd> <kbd>Down</kbd> |
+| Move Window     | <kbd>Win</kbd>+<kbd>Ctrl</kbd> |   <kbd>Up</kbd> <kbd>Down</kbd>  | Move to Workspace | <kbd>Win</kbd>+<kbd>Shift</kbd> | <kbd>PgDn</kbd> <kbd>PgUp</kbd> <kbd>Home</kbd> <kbd>End</kbd> |
+| Resize Window   |  <kbd>Win</kbd>+<kbd>Alt</kbd> | <kbd>Plus</kbd> <kbd>Minus</kbd> | Zoom              |  <kbd>Win</kbd>+<kbd>Alt</kbd>  |                <kbd>Plus</kbd> <kbd>Minus</kbd>                |
+| Un-minimize     |         <kbd>Win</kbd>         |   <kbd>Shift</kbd>+<kbd>H</kbd>  | Minimize / Hide   |          <kbd>Win</kbd>         |                          <kbd>H</kbd>                          |
+
+### Deprecated hotkeys
+
+Hotkeys with similar functionality in gnome shell.
+
+|                           Keyboard                          | Action                             |                                                  Gnome Similar                                                  |
+|:-----------------------------------------------------------:|------------------------------------|:---------------------------------------------------------------------------------------------------------------:|
+| <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>H</kbd> | Minimize window                    |                                            <kbd>Win</kbd><kbd>H</kbd>                                           |
+|          <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd>         | Next workspace                     |                  <kbd>Win</kbd>+<kbd>PgDn</kbd> <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Down</kbd>                  |
+|          <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd>         | Previous workspace                 |                   <kbd>Win</kbd>+<kbd>PgUp</kbd> <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Up</kbd>                   |
+| <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> | Bring window to next workspace     | <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>PgDn</kbd> <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>Down</kbd> |
+| <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd> | Bring window to previous workspace |  <kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>PgUp</kbd> <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>Up</kbd>  |
 
 ---
 
@@ -58,23 +100,25 @@ These can be uses as-is in "modify mode", or used globally (without showing slin
 
 Install required dependencies:
 
- - `tsc` (typescript)
+* `tsc` (typescript)
 
 Compile:
 
-```
-tools/gup compile
+```bash
+tools/gup compile -v
 ```
 
 Install:
 
-```
-ln -sfn $PWD/extension ~/.local/share/gnome-shell/extensions/slinger@gfxmonk.net
+```bash
+mkdir -p ~/.local/share/gnome-shell/extensions/slinger@gfxmonk.net/schemas
+cp  --verbose $PWD/extension/*.* ~/.local/share/gnome-shell/extensions/slinger@gfxmonk.net/
+cp  --dereference --verbose $PWD/extension/schemas/*.* ~/.local/share/gnome-shell/extensions/slinger@gfxmonk.net/schemas/
 ```
 
 ---
 
-### History.
+### History
 
 Slinger was born out of [shellshape](https://github.com/timbertson/shellshape/), a Gnome Shell extension I created for automatically tiling windows. Shellshape is useful, but it's also buggy and has a lot of ugly interactions with the window system (which itself has plenty of bugs).
 
@@ -88,4 +132,10 @@ Truthfully, slinger was created because shellshape is not worth my time to maint
 
 Another benefit of a stateless app is that it's more easily portable to different window systems. There is an OSX version [here](https://github.com/timbertson/Slinger.app), which lacks a few features, but mostly works.
 
-
+<kbd>&nbsp;&nbsp;⊞&nbsp;&nbsp;</kbd>
+<kbd>&nbsp;&nbsp;▲&nbsp;&nbsp;</kbd>
+<kbd>&nbsp;&nbsp;▼&nbsp;&nbsp;</kbd>
+<kbd>&nbsp;&nbsp;◀&nbsp;&nbsp;</kbd>
+<kbd>&nbsp;&nbsp;▶&nbsp;&nbsp;</kbd>
+<kbd>&nbsp;&nbsp;**+**&nbsp;&nbsp;</kbd>
+<kbd>&nbsp;&nbsp;**-**&nbsp;&nbsp;</kbd>

--- a/schemas/org.gnome.shell.extensions.net.gfxmonk.slinger.keybindings.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.net.gfxmonk.slinger.keybindings.gschema.xml
@@ -1,37 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-	<schema id="org.gnome.shell.extensions.net.gfxmonk.slinger.keybindings" path="/org/gnome/shell/extensions/net/gfxmonk/slinger/keybindings/">
-		<key type="as" name="slinger-show">                        <default>["&lt;Mod4&gt;a"]</default><summary>Show the slinger UI</summary><description></description></key>
+	<schema id="org.gnome.shell.extensions.net.gfxmonk.slinger.keybindings" 
+			path="/org/gnome/shell/extensions/net/gfxmonk/slinger/keybindings/">
+	
+		<!-- See reference at: https://gitlab.gnome.org/GNOME/gtk/raw/master/gdk/gdkkeysyms.h --> 
+		
+		<key type="as" name="slinger-show">                        <default>["&lt;Mod4&gt;w"]</default><summary>Show arrange window menu</summary><description></description></key>
+		<key type="as" name="slinger-distribute">                  <default>["&lt;Mod4&gt;g"]</default><summary>Distribute/tile/splat windows side by side</summary><description>Distribute windows.</description></key>
+		<key type="as" name="slinger-fill-available-space">        <default>["&lt;Mod4&gt;f"]</default><summary>Fill available space with window</summary><description>Fill available space.</description></key>
 
-		<key type="as" name="slinger-next-window">                 <default>["&lt;Mod4&gt;j", "&lt;Mod4&gt;Tab"]</default><summary>Change focus to the next window</summary><description>Change focus to the next window.</description></key>
-		<key type="as" name="slinger-prev-window">                 <default>["&lt;Mod4&gt;k", "&lt;Mod4&gt;&lt;Shift&gt;Tab"]</default><summary>Change focus to the previous window</summary><description>Change focus to the previous window.</description></key>
+		<key type="as" name="slinger-swap-next-window">            <default>["&lt;Mod4&gt;&lt;Alt&gt;Right","&lt;Mod4&gt;&lt;Alt&gt;KP_Right"]</default><summary>Swap with next window</summary><description>Swap with next window.</description></key>
+		<key type="as" name="slinger-swap-prev-window">            <default>["&lt;Mod4&gt;&lt;Alt&gt;Left","&lt;Mod4&gt;&lt;Alt&gt;KP_Left"]</default><summary>Swap with previous window</summary><description>Swap with prev window.</description></key>
+		<key type="as" name="slinger-swap-largest-window">         <default>["&lt;Mod4&gt;&lt;Alt&gt;Up","&lt;Mod4&gt;&lt;Alt&gt;KP_Up"]</default><summary>Swap with largest window</summary><description>Swap with largest window.</description></key>
 
-		<key type="as" name="slinger-swap-next-window">            <default>["&lt;Mod4&gt;&lt;Shift&gt;j"]</default><summary>Swap with next window</summary><description>Swap with next window.</description></key>
-		<key type="as" name="slinger-swap-prev-window">            <default>["&lt;Mod4&gt;&lt;Shift&gt;k"]</default><summary>Swap with prev window</summary><description>Swap with prev window.</description></key>
-		<key type="as" name="slinger-swap-largest-window">         <default>["&lt;Mod4&gt;&lt;Shift&gt;space"]</default><summary>Swap with prev window</summary><description>Swap with prev window.</description></key>
+		<key type="as" name="slinger-move-right">                  <default>["&lt;Mod4&gt;&lt;Control&gt;Right","&lt;Mod4&gt;&lt;Control&gt;KP_Right"]</default><summary>Grow master area</summary><description>Grow master area.</description></key>
+		<key type="as" name="slinger-move-left">                   <default>["&lt;Mod4&gt;&lt;Control&gt;Left","&lt;Mod4&gt;&lt;Control&gt;KP_Left"]</default><summary>Shrink master area</summary><description>Shrink master area.</description></key>
+		<key type="as" name="slinger-move-up">                     <default>["&lt;Mod4&gt;&lt;Control&gt;Up","&lt;Mod4&gt;&lt;Control&gt;KP_Up"]</default><summary>grow a slave area</summary><description>grow a slave area.</description></key>
+		<key type="as" name="slinger-move-down">                   <default>["&lt;Mod4&gt;&lt;Control&gt;Down","&lt;Mod4&gt;&lt;Control&gt;KP_Down"]</default><summary>Shrink a slave area</summary><description>Shrink a slave area.</description></key>
 
-		<key type="as" name="slinger-move-right">                  <default>["&lt;Mod4&gt;l"]</default><summary>Grow master area</summary><description>Grow master area.</description></key>
-		<key type="as" name="slinger-move-left">                   <default>["&lt;Mod4&gt;h"]</default><summary>Shrink master area</summary><description>Shrink master area.</description></key>
-		<key type="as" name="slinger-move-up">                     <default>["&lt;Mod4&gt;i"]</default><summary>grow a slave area</summary><description>grow a slave area.</description></key>
-		<key type="as" name="slinger-move-down">                   <default>["&lt;Mod4&gt;u"]</default><summary>Shrink a slave area</summary><description>Shrink a slave area.</description></key>
+		<key type="as" name="slinger-grow-horizontal">             <default>["&lt;Mod4&gt;&lt;Alt&gt;Plus","&lt;Mod4&gt;&lt;Alt&gt;KP_Add"]</default><summary>Increase window's width</summary><description>Increase window's width.</description></key>
+		<key type="as" name="slinger-shrink-horizontal">           <default>["&lt;Mod4&gt;&lt;Alt&gt;Minus","&lt;Mod4&gt;&lt;Alt&gt;KP_Subtract"]</default><summary>Decrease window's width</summary><description>Decrease window's width.</description></key>
+		<key type="as" name="slinger-grow-vertical">               <default>["&lt;Mod4&gt;&lt;Alt&gt;Asterisk","&lt;Mod4&gt;&lt;Alt&gt;KP_Multiply"]</default><summary>Increase window's height</summary><description>Increase window's height.</description></key>
+		<key type="as" name="slinger-shrink-vertical">             <default>["&lt;Mod4&gt;&lt;Alt&gt;Slash","&lt;Mod4&gt;&lt;Alt&gt;KP_Divide"]</default><summary>Decrease window's height</summary><description>Decrease window's height.</description></key>
+		<key type="as" name="slinger-grow">                        <default>["&lt;Mod4&gt;Plus","&lt;Mod4&gt;KP_Add"]</default><summary>Increase window's size</summary><description>Increase window's size.</description></key>
+		<key type="as" name="slinger-shrink">                      <default>["&lt;Mod4&gt;Minus","&lt;Mod4&gt;KP_Subtract"]</default><summary>Decrease window's size</summary><description>Decrease window's size.</description></key>
 
-		<key type="as" name="slinger-grow-horizontal">             <default>["&lt;Mod4&gt;&lt;Shift&gt;l"]</default><summary>Increase window's width</summary><description>Increase window's width.</description></key>
-		<key type="as" name="slinger-shrink-horizontal">           <default>["&lt;Mod4&gt;&lt;Shift&gt;h"]</default><summary>Decrease window's width</summary><description>Decrease window's width.</description></key>
-		<key type="as" name="slinger-grow-vertical">               <default>["&lt;Mod4&gt;&lt;Shift&gt;u"]</default><summary>Increase window's height</summary><description>Increase window's height.</description></key>
-		<key type="as" name="slinger-shrink-vertical">             <default>["&lt;Mod4&gt;&lt;Shift&gt;i"]</default><summary>Decrease window's height</summary><description>Decrease window's height.</description></key>
-		<key type="as" name="slinger-grow">                        <default>["&lt;Mod4&gt;equal"]</default><summary>Increase window's size</summary><description>Increase window's size.</description></key>
-		<key type="as" name="slinger-shrink">                      <default>["&lt;Mod4&gt;minus"]</default><summary>Decrease window's size</summary><description>Decrease window's size.</description></key>
+		<key type="as" name="slinger-toggle-maximize">             <default>["&lt;Mod4&gt;&lt;Alt&gt;h"]</default><summary>Toggle window maximized state</summary><description>Toggle window maximized state.</description></key>
+		<key type="as" name="slinger-unminimize-window">           <default>["&lt;Mod4&gt;&lt;Shift&gt;h"]</default><summary>Un-minimize last window</summary><description>Un-minimize last window.</description></key>
+
+		<!-- DEPRECATED: confliting or duplicated shortcuts with gnome  -->
+		
+		<key type="as" name="slinger-minimize-window">             <default>["&lt;Mod4&gt;&lt;Alt&gt;&lt;Shift&gt;x"]</default><summary>Minimize window</summary><description>Minimize window.</description></key>
+		<key type="as" name="slinger-next-window">                 <default>["&lt;Mod4&gt;&lt;Alt&gt;Tab"]</default><summary>Change focus to the next window</summary><description>Change focus to the next window.</description></key>
+		<key type="as" name="slinger-prev-window">                 <default>["&lt;Mod4&gt;&lt;Shift&gt;&lt;Alt&gt;Tab"]</default><summary>Change focus to the previous window</summary><description>Change focus to the previous window.</description></key>
 
 		<key type="as" name="slinger-switch-workspace-up">         <default>["&lt;Mod4&gt;&lt;Alt&gt;k"]</default><summary>Go to workspace above</summary><description>Go to workspace above.</description></key>
 		<key type="as" name="slinger-switch-workspace-down">       <default>["&lt;Mod4&gt;&lt;Alt&gt;j"]</default><summary>Go to workspace below</summary><description>Go to workspace below.</description></key>
 		<key type="as" name="slinger-move-window-workspace-up">    <default>["&lt;Mod4&gt;&lt;Alt&gt;&lt;Shift&gt;k"]</default><summary>Move window to workspace above</summary><description>Move window to workspace above.</description></key>
 		<key type="as" name="slinger-move-window-workspace-down">  <default>["&lt;Mod4&gt;&lt;Alt&gt;&lt;Shift&gt;j"]</default><summary>Move window to workspace below</summary><description>Move window to workspace below.</description></key>
-
-		<key type="as" name="slinger-toggle-maximize">             <default>["&lt;Mod4&gt;z"]</default><summary>Toggle window maximized state</summary><description>Toggle window maximized state.</description></key>
-		<key type="as" name="slinger-minimize-window">             <default>["&lt;Mod4&gt;x"]</default><summary>Minimize window</summary><description>Minimize window.</description></key>
-		<key type="as" name="slinger-unminimize-window">           <default>["&lt;Mod4&gt;&lt;Shift&gt;x"]</default><summary>Un-minimize last window</summary><description>Un-minimize last window.</description></key>
-
-		<key type="as" name="slinger-distribute">                  <default>["&lt;Mod4&gt;&lt;Shift&gt;8"]</default><summary>Distribute windows</summary><description>Distribute windows.</description></key>
-		<key type="as" name="slinger-fill-available-space">        <default>["&lt;Mod4&gt;8"]</default><summary>Fill available space</summary><description>Fill available space.</description></key>
+		
 	</schema>
 </schemalist>


### PR DESCRIPTION
## Shortcut Conflicts

1. Key [Win]+[A] conflicts:
	* with Gnome 'show applications'. 

2. Keys [Win]+[Tab]/[Win]+[Shift]+[Tab] conflicts:
	* with Gnome 'alternate window' 
	* other extensions like Coverflow alt-tab. 

3. Key [Win]+[L] conflicts:
	* with Gnome 'Lock Screen'. 

4. Key [Win]+[H] conflicts:
	* with Gnome 'Minimize Window'. 

5. Key [Win]+[I] conflicts:
	* with extension 'Dash to panel' command 'show/hide top bar'. 

6. Key [Win]+[Shift]+[8] conflicts:
	* with appliation launchers. 

## Duplicated commands:

1. Workplace commands have other shortcut in Gnome:
	* Slinger shortcuts:
		- Go to workspace above - [Win]+[Alt]+[k] 
		- Go to workspace below - [Win]+[Alt]+[j] 
		- Move window to workspace above - [Win]+[Alt]+[Shift]+[k] 
		- Move window to workspace below - [Win]+[Alt]+[Shift]+[j] 
	* does in gnome the same as:
		- [Win]+[PgUp] or [Ctrl]+[Alt]+[Shift]+[UpArrow]
		- [Win]+[PgDow] or [Ctrl]+[Alt]+[Shift]+[DownArrow]
		- [Win]+[Shift]+[PgUp]
		- [Win]+[Shift]+[PgDow]

2. Maximize/minimize commands have other shortcut in Gnome:
	* Slinger shortcuts:
		- Minimize window - [Win]+[X] 
		- Toggle window maximized state (partially) - [Win]+[Z]+
		- Move window to workspace above - [Win]+[Alt]+[Shift]+[k] 
		- Move window to workspace below - [Win]+[Alt]+[Shift]+[j] 
	* does in gnome the same as:
		- [Win]+[H]
		- [Win]+[UpArrow]
		- [Win]+[Shift]+[PgUp]
		- [Win]+[Shift]+[PgDow]

## Inconscistencies:

1. Grow/Shrink are associated to  [Win]+[equal] and [Win]+[minus] 
	* Expected [Win]+[plus] and [Win]+[minus] for easy remembering. 
2. Grow/Shrink Horizontal/Vertical does not follow a shortcut pattern with Grow/Shrink.
	* Expected [Win]+[Modifier]+[plus] and [Win]+[Modifier]+[minus] for easy remembering. 
3. Move Up/Down/Left/Rigth Horizontal/Vertical does not follow a shortcut pattern with Gnome Tile Left/Right [Win]+[LeftArrow] / [Win]+[RightArrow] .
	* Expected [Win]+[Modifier]+[Up/Down/Left/Right] and [Win]+[Modifier]+[minus] for easy remembering. 
4. [Win] + H/J/K/L and [Win] + I/U mnemonics broken by conflicts.
    * Cant really use depending on extensions installed