### PR TITLE
Update menu grab code to accommodate disappearance of  Sys.Clutter.grab* functions

### DIFF
--- a/gup/extension/all.gup
+++ b/gup/extension/all.gup
@@ -1,7 +1,7 @@
 #!bash -eu
 gup -u \
 	extension_impl.js \
-	cocoa_impl.js \
-	clutter_test.js \
 	extension.js \
 	;
+	#cocoa_impl.js \
+	#clutter_test.js \

--- a/src/cocoa_impl.ts
+++ b/src/cocoa_impl.ts
@@ -43,10 +43,6 @@ module Wrapper {
 			let get = makeGetters(obj);
 			return {
 				EVENT_STOP: ((get.prop('EVENT_STOP') as any) as ClutterEventResponse),
-				grab_pointer: get.fn('grab_pointer'),
-				grab_keyboard: get.fn('grab_keyboard'),
-				ungrab_pointer: get.fn('ungrab_pointer'),
-				ungrab_keyboard: get.fn('ungrab_keyboard'),
 				ModifierType: {
 					SHIFT_MASK: (get.prop('SHIFT_MASK') as number),
 				}

--- a/src/common.ts
+++ b/src/common.ts
@@ -32,10 +32,6 @@ type Actor = Connectable & {
 };
 interface ClutterModule {
 	EVENT_STOP: ClutterEventResponse
-	grab_pointer(actor: Actor): void
-	ungrab_pointer(): void
-	grab_keyboard(actor: Actor): void
-	ungrab_keyboard(): void
 	ModifierType: {
 		SHIFT_MASK: number
 	}
@@ -45,6 +41,10 @@ interface Connectable {
 	connect(signal: String, handler: Function): void
 }
 
+interface ClutterInputDevice {
+        grab(actor: Actor): void
+        ungrab(): void
+};
 interface ClutterMouseEvent {
 	get_coords(): Array<number>
 };

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -109,6 +109,8 @@ module Menu {
 		private Sys: System<WindowType>;
 		private win: WindowType;
 		private splitMode: SplitMode;
+		private _pointerDevice: ClutterInputDevice;
+		private _keyboardDevice: ClutterInputDevice;
 
 		static show<WindowType>(Sys: System<WindowType>,
 				parent: Actor,
@@ -165,8 +167,12 @@ module Menu {
 				return Sys.Clutter.EVENT_STOP;
 			});
 
-			Sys.Clutter.grab_pointer(backgroundActor);
-			Sys.Clutter.grab_keyboard(backgroundActor);
+			let dm = Clutter.DeviceManager.get_default();
+			this._pointerDevice = dm.get_core_device(Clutter.InputDeviceType.POINTER_DEVICE);
+			this._keyboardDevice = dm.get_core_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
++
+			this._pointerDevice.grab(backgroundActor);
+			this._keyboardDevice.grab(backgroundActor);
 
 			// var suspendedMouseMode = MouseMode.NOOP;
 			backgroundActor.connect('key-press-event', function(_actor: Actor, event: ClutterKeyEvent) {
@@ -292,8 +298,8 @@ module Menu {
 		destroy() {
 			p("hiding menu")
 			if (this.displayed()) {
-				this.Sys.Clutter.ungrab_pointer();
-				this.Sys.Clutter.ungrab_keyboard();
+				this._pointerDevice.ungrab();
+				this._keyboardDevice.ungrab();
 				this.parent.remove_child(this.ui);
 				this.parent = null;
 			}


### PR DESCRIPTION
Still to do:

- [ ] This currently simply disables Cocoa and `clutter_test.js`. Those should be revived.
- [ ] Stops working after keyboard hotplug until Shell restart, https://gitlab.gnome.org/GNOME/mutter/issues/799

Closes #19